### PR TITLE
Bump up OpenVINO 2024.2.0 and restrict numpy to 1.x

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,9 +9,9 @@ build-backend = "setuptools.build_meta"
 name = "openvino_xai"
 version = "1.1.0rc01"
 dependencies = [
-  "openvino-dev==2023.2",
+  "openvino-dev==2024.2",
   "opencv-python",
-  "numpy",
+  "numpy==1.*",
   "tqdm",
 ]
 requires-python = ">=3.10"


### PR DESCRIPTION
Full e2e test: https://github.com/openvinotoolkit/openvino_xai/actions/runs/9556903096/job/26343210694