### PR TITLE
Extend some explainer/visualizer capabilities and Fix pre-release bugs

### DIFF
--- a/openvino_xai/explainer/explainer.py
+++ b/openvino_xai/explainer/explainer.py
@@ -13,6 +13,7 @@ from openvino_xai.common.parameters import Method
 from openvino_xai.common.utils import IdentityPreprocessFN, logger
 from openvino_xai.explainer.explanation import Explanation
 from openvino_xai.explainer.utils import (
+    convert_targets_to_numpy,
     explains_all,
     get_explain_target_indices,
     infer_size_from_image,
@@ -190,8 +191,7 @@ class Explainer:
         :parameter overlay_weight: Weight of the saliency map when overlaying the input data with the saliency map.
         :type overlay_weight: float
         """
-        if isinstance(targets, (int, str)):
-            targets = [targets]
+        targets = convert_targets_to_numpy(targets)
 
         explain_target_indices = None
         if isinstance(self.method, BlackBoxXAIMethod) and not explains_all(targets):

--- a/openvino_xai/explainer/explainer.py
+++ b/openvino_xai/explainer/explainer.py
@@ -131,6 +131,7 @@ class Explainer:
         self,
         data: np.ndarray,
         targets: np.ndarray | List[int | str] | int | str,
+        original_input_image: np.ndarray | None = None,
         label_names: List[str] | None = None,
         output_size: Tuple[int, int] | None = None,
         scaling: bool = False,
@@ -143,6 +144,7 @@ class Explainer:
         return self.explain(
             data,
             targets,
+            original_input_image,
             label_names,
             output_size,
             scaling,
@@ -157,6 +159,7 @@ class Explainer:
         self,
         data: np.ndarray,
         targets: np.ndarray | List[int | str] | int | str,
+        original_input_image: np.ndarray | None = None,
         label_names: List[str] | None = None,
         output_size: Tuple[int, int] | None = None,
         scaling: bool = False,
@@ -212,6 +215,7 @@ class Explainer:
             label_names=label_names,
         )
         return self._visualize(
+            original_input_image,
             explanation,
             data,
             output_size,
@@ -248,9 +252,10 @@ class Explainer:
 
     def _visualize(
         self,
+        original_input_image: np.ndarray | None,
         explanation: Explanation,
         data: np.ndarray,
-        output_size: Tuple[int, int],
+        output_size: Tuple[int, int] | None,
         scaling: bool,
         resize: bool,
         colormap: bool,
@@ -258,11 +263,12 @@ class Explainer:
         overlay_weight: float,
     ) -> Explanation:
         if output_size is None:
-            output_size = infer_size_from_image(data)  # resize to model input by default
+            reference_image = data if original_input_image is None else original_input_image
+            output_size = infer_size_from_image(reference_image)
 
         explanation = self.visualizer(
             explanation=explanation,
-            original_input_image=data,
+            original_input_image=data if original_input_image is None else original_input_image,
             output_size=output_size,
             scaling=scaling,
             resize=resize,

--- a/openvino_xai/explainer/explainer.py
+++ b/openvino_xai/explainer/explainer.py
@@ -129,7 +129,7 @@ class Explainer:
     def __call__(
         self,
         data: np.ndarray,
-        targets: List[int | str] | int | str,
+        targets: np.ndarray | List[int | str] | int | str,
         label_names: List[str] | None = None,
         output_size: Tuple[int, int] | None = None,
         scaling: bool = False,
@@ -155,7 +155,7 @@ class Explainer:
     def explain(
         self,
         data: np.ndarray,
-        targets: List[int | str] | int | str,
+        targets: np.ndarray | List[int | str] | int | str,
         label_names: List[str] | None = None,
         output_size: Tuple[int, int] | None = None,
         scaling: bool = False,
@@ -172,7 +172,7 @@ class Explainer:
         :type data: np.ndarray
         :param targets: List of custom labels to explain, optional. Can be list of integer indices (int),
             or list of names (str) from label_names.
-        :type targets: List[int | str] | int | str
+        :type targets: np.ndarray | List[int | str] | int | str
         :param label_names: List of all label names.
         :type label_names: List[str] | None
         :param output_size: Output size used for resize operation.

--- a/openvino_xai/explainer/explanation.py
+++ b/openvino_xai/explainer/explanation.py
@@ -134,7 +134,8 @@ class Explanation:
                     target_name = self.label_names[cls_idx]
                 else:
                     target_name = str(cls_idx)
-            cv2.imwrite(os.path.join(dir_path, f"{save_name}_target_{target_name}.jpg"), img=map_to_save)
+            image_name = f"{save_name}_target_{target_name}.jpg" if save_name else f"target_{target_name}.jpg"
+            cv2.imwrite(os.path.join(dir_path, image_name), img=map_to_save)
 
 
 class Layout(Enum):

--- a/openvino_xai/explainer/explanation.py
+++ b/openvino_xai/explainer/explanation.py
@@ -9,7 +9,7 @@ from typing import Dict, List
 import cv2
 import numpy as np
 
-from openvino_xai.explainer.utils import explains_all, get_explain_target_indices
+from openvino_xai.explainer.utils import convert_targets_to_numpy, explains_all, get_explain_target_indices
 
 
 class Explanation:
@@ -30,8 +30,7 @@ class Explanation:
         targets: np.ndarray | List[int | str] | int | str,
         label_names: List[str] | None = None,
     ):
-        if isinstance(targets, (int, str)):
-            targets = [targets]
+        targets = convert_targets_to_numpy(targets)
 
         self._check_saliency_map(saliency_map)
         self._saliency_map = self._format_sal_map_as_dict(saliency_map)

--- a/openvino_xai/explainer/explanation.py
+++ b/openvino_xai/explainer/explanation.py
@@ -119,7 +119,8 @@ class Explanation:
         """Dumps saliency map."""
         os.makedirs(dir_path, exist_ok=True)
         save_name = name if name else ""
-        for i, (cls_idx, map_to_save) in enumerate(self._saliency_map.items()):
+        for cls_idx, map_to_save in self._saliency_map.items():
+            map_to_save = cv2.cvtColor(map_to_save, code=cv2.COLOR_RGB2BGR)
             if isinstance(cls_idx, str):
                 cv2.imwrite(os.path.join(dir_path, f"{save_name}.jpg"), img=map_to_save)
                 return

--- a/openvino_xai/explainer/explanation.py
+++ b/openvino_xai/explainer/explanation.py
@@ -9,7 +9,11 @@ from typing import Dict, List
 import cv2
 import numpy as np
 
-from openvino_xai.explainer.utils import convert_targets_to_numpy, explains_all, get_explain_target_indices
+from openvino_xai.explainer.utils import (
+    convert_targets_to_numpy,
+    explains_all,
+    get_explain_target_indices,
+)
 
 
 class Explanation:

--- a/openvino_xai/explainer/explanation.py
+++ b/openvino_xai/explainer/explanation.py
@@ -47,7 +47,7 @@ class Explanation:
 
     @property
     def saliency_map(self) -> Dict[int | str, np.ndarray]:
-        """Saliency map as a dict {map_id: np.ndarray}."""
+        """Saliency map as a dict {target_id: np.ndarray}."""
         return self._saliency_map
 
     @saliency_map.setter
@@ -56,9 +56,15 @@ class Explanation:
 
     @property
     def shape(self):
+        """Shape of the saliency map."""
         idx = next(iter(self._saliency_map))
         shape = self._saliency_map[idx].shape
         return shape
+
+    @property
+    def targets(self):
+        """Explained targets."""
+        return list(self._saliency_map.keys())
 
     @staticmethod
     def _check_saliency_map(saliency_map: np.ndarray):

--- a/openvino_xai/explainer/explanation.py
+++ b/openvino_xai/explainer/explanation.py
@@ -19,7 +19,7 @@ class Explanation:
     :param saliency_map: Raw saliency map.
     :param targets: List of custom labels to explain, optional. Can be list of integer indices (int),
         or list of names (str) from label_names.
-    :type targets: List[int | str] | int | str
+    :type targets: np.ndarray | List[int | str] | int | str
     :param label_names: List of all label names.
     :type label_names: List[str] | None
     """
@@ -27,7 +27,7 @@ class Explanation:
     def __init__(
         self,
         saliency_map: np.ndarray,
-        targets: List[int | str] | int | str,
+        targets: np.ndarray | List[int | str] | int | str,
         label_names: List[str] | None = None,
     ):
         if isinstance(targets, (int, str)):
@@ -92,7 +92,7 @@ class Explanation:
 
     def _select_target_saliency_maps(
         self,
-        targets: List[int | str],
+        targets: np.ndarray | List[int | str],
         label_names: List[str] | None = None,
     ) -> Dict[int | str, np.ndarray]:
         assert self.layout == Layout.MULTIPLE_MAPS_PER_IMAGE_GRAY
@@ -106,7 +106,7 @@ class Explanation:
 
     @staticmethod
     def _select_target_indices(
-        targets: List[int | str],
+        targets: np.ndarray | List[int | str],
         total_num_targets: int,
         label_names: List[str] | None = None,
     ) -> List[int] | np.ndarray:

--- a/openvino_xai/explainer/utils.py
+++ b/openvino_xai/explainer/utils.py
@@ -9,6 +9,13 @@ import numpy as np
 from openvino.runtime.utils.data_helpers.wrappers import OVDict
 
 
+def convert_targets_to_numpy(targets):
+    targets = np.asarray(targets)
+    if targets.ndim > 1:
+        raise ValueError(f"targets expected to be at most 1-dimentional, but got {targets.ndim}.")
+    return np.atleast_1d(targets)
+
+
 def get_explain_target_indices(
     targets: np.ndarray | List[int | str],
     label_names: List[str] | None = None,
@@ -22,12 +29,9 @@ def get_explain_target_indices(
     :param label_names: List of all label names.
     :type label_names: List[str] | None
     """
-    if isinstance(targets, np.ndarray):
-        if targets.ndim != 1:
-            raise ValueError(f"Expected 1d numpy array, but got {targets.ndim}.")
-        return list(targets)
+    targets = convert_targets_to_numpy(targets)
 
-    if isinstance(targets[0], int):
+    if not isinstance(targets[0], str) and np.issubdtype(targets[0], np.integer):
         return targets  # type: ignore
 
     if not isinstance(targets[0], str):
@@ -55,7 +59,7 @@ def explains_all(targets: List[int | str] | int | str):
     """
     if isinstance(targets, int) and targets == -1:
         return True
-    if isinstance(targets, list) and len(targets) == 1 and targets[0] == -1:
+    if isinstance(targets, (np.ndarray, list)) and len(targets) == 1 and targets[0] == -1:
         return True
     if isinstance(targets, str) and targets == "-1":
         return True

--- a/openvino_xai/explainer/utils.py
+++ b/openvino_xai/explainer/utils.py
@@ -146,3 +146,33 @@ def get_score(x: np.ndarray, index: int, activation: ActivationType = Activation
         assert x.shape[0] == 1
         return x[0, index]
     return x[index]
+
+
+def format_to_hwc(image: np.ndarray) -> np.ndarray:
+    """Format image to HWC."""
+    ori_ndim = image.ndim
+    if image.ndim == 4:
+        image = np.squeeze(image, axis=0)
+
+    dim0, dim1, dim2 = image.shape
+    if dim0 < dim1 and dim0 < dim2:
+        image = image.transpose((1, 2, 0))
+
+    if ori_ndim:
+        return np.expand_dims(image, axis=0)
+    return image
+
+
+def infer_size_from_image(image: np.ndarray) -> Tuple[int, int]:
+    """Estimate image size."""
+    image = format_to_hwc(image)
+
+    if image.ndim == 2:
+        return image.shape
+    elif image.ndim == 3:
+        h, w, _ = image.shape
+    elif image.ndim == 4:
+        _, h, w, _ = image.shape
+    else:
+        raise ValueError(f"Supports only two, three, and four dimensional image, but got {image.ndim}.")
+    return h, w

--- a/openvino_xai/explainer/utils.py
+++ b/openvino_xai/explainer/utils.py
@@ -10,7 +10,7 @@ from openvino.runtime.utils.data_helpers.wrappers import OVDict
 
 
 def get_explain_target_indices(
-    targets: List[int | str],
+    targets: np.ndarray | List[int | str],
     label_names: List[str] | None = None,
 ) -> List[int]:
     """
@@ -18,10 +18,15 @@ def get_explain_target_indices(
 
     :param targets: List of custom labels to explain, optional. Can be list of integer indices (int),
         or list of names (str) from label_names.
-    :type targets: List[int | str]
+    :type targets: np.ndarray | List[int | str]
     :param label_names: List of all label names.
     :type label_names: List[str] | None
     """
+    if isinstance(targets, np.ndarray):
+        if targets.ndim != 1:
+            raise ValueError(f"Expected 1d numpy array, but got {targets.ndim}.")
+        return list(targets)
+
     if isinstance(targets[0], int):
         return targets  # type: ignore
 

--- a/openvino_xai/explainer/visualizer.py
+++ b/openvino_xai/explainer/visualizer.py
@@ -32,7 +32,9 @@ def colormap(saliency_map: np.ndarray, colormap_type: int = cv2.COLORMAP_JET) ->
     # Note: inefficient operation. Is there a way to vectorize it?
     color_mapped_saliency_map = []
     for class_map in saliency_map:
-        color_mapped_saliency_map.append(cv2.applyColorMap(class_map, colormap_type))
+        colormapped = cv2.applyColorMap(class_map, colormap_type)  # OpenCV: RGB order
+        colormapped_rgb = cv2.cvtColor(colormapped, code=cv2.COLOR_BGR2RGB)
+        color_mapped_saliency_map.append(colormapped_rgb)
     return np.array(color_mapped_saliency_map)
 
 

--- a/openvino_xai/explainer/visualizer.py
+++ b/openvino_xai/explainer/visualizer.py
@@ -32,7 +32,7 @@ def colormap(saliency_map: np.ndarray, colormap_type: int = cv2.COLORMAP_JET) ->
     # Note: inefficient operation. Is there a way to vectorize it?
     color_mapped_saliency_map = []
     for class_map in saliency_map:
-        colormapped = cv2.applyColorMap(class_map, colormap_type)  # OpenCV: RGB order
+        colormapped = cv2.applyColorMap(class_map, colormap_type)  # OpenCV: BGR order
         colormapped_rgb = cv2.cvtColor(colormapped, code=cv2.COLOR_BGR2RGB)
         color_mapped_saliency_map.append(colormapped_rgb)
     return np.array(color_mapped_saliency_map)

--- a/openvino_xai/explainer/visualizer.py
+++ b/openvino_xai/explainer/visualizer.py
@@ -38,7 +38,9 @@ def colormap(saliency_map: np.ndarray, colormap_type: int = cv2.COLORMAP_JET) ->
     return np.array(color_mapped_saliency_map)
 
 
-def overlay(saliency_map: np.ndarray, input_image: np.ndarray, overlay_weight: float = 0.5, cast_to_uint8: bool = True) -> np.ndarray:
+def overlay(
+    saliency_map: np.ndarray, input_image: np.ndarray, overlay_weight: float = 0.5, cast_to_uint8: bool = True
+) -> np.ndarray:
     """Applies overlay of the saliency map with the original image."""
     res = input_image * overlay_weight + saliency_map * (1 - overlay_weight)
     res[res > 255] = 255

--- a/openvino_xai/explainer/visualizer.py
+++ b/openvino_xai/explainer/visualizer.py
@@ -55,7 +55,7 @@ class Visualizer:
     def __call__(
         self,
         explanation: Explanation,
-        original_input_image: np.ndarray = None,
+        original_input_image: np.ndarray | None = None,
         output_size: Tuple[int, int] = None,
         scaling: bool = False,
         resize: bool = True,
@@ -77,7 +77,7 @@ class Visualizer:
     def visualize(
         self,
         explanation: Explanation,
-        original_input_image: np.ndarray = None,
+        original_input_image: np.ndarray | None = None,
         output_size: Tuple[int, int] = None,
         scaling: bool = False,
         resize: bool = True,

--- a/openvino_xai/explainer/visualizer.py
+++ b/openvino_xai/explainer/visualizer.py
@@ -36,10 +36,12 @@ def colormap(saliency_map: np.ndarray, colormap_type: int = cv2.COLORMAP_JET) ->
     return np.array(color_mapped_saliency_map)
 
 
-def overlay(saliency_map: np.ndarray, input_image: np.ndarray, overlay_weight: float = 0.5) -> np.ndarray:
+def overlay(saliency_map: np.ndarray, input_image: np.ndarray, overlay_weight: float = 0.5, cast_to_uint8: bool = True) -> np.ndarray:
     """Applies overlay of the saliency map with the original image."""
     res = input_image * overlay_weight + saliency_map * (1 - overlay_weight)
     res[res > 255] = 255
+    if cast_to_uint8:
+        return res.astype(np.uint8)
     return res
 
 

--- a/openvino_xai/methods/black_box/rise.py
+++ b/openvino_xai/methods/black_box/rise.py
@@ -132,7 +132,7 @@ class RISE(BlackBoxXAIMethod):
 
     @staticmethod
     def _get_scored_mask(raw_scores: np.ndarray, mask: np.ndarray, target_classes: List[int] | None) -> np.ndarray:
-        if target_classes:
+        if target_classes is not None:
             return np.take(raw_scores, target_classes).reshape(-1, 1, 1) * mask
         else:
             return raw_scores.reshape(-1, 1, 1) * mask

--- a/openvino_xai/methods/white_box/base.py
+++ b/openvino_xai/methods/white_box/base.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from abc import abstractmethod
+import copy
 from typing import Callable
 from venv import logger
 
@@ -38,7 +39,7 @@ class WhiteBoxMethod(MethodBase):
         embed_scaling: bool = True,
     ):
         super().__init__(preprocess_fn=preprocess_fn)
-        self._model_ori = model
+        self._model_ori = copy.deepcopy(model)
         self.preprocess_fn = preprocess_fn
         self.embed_scaling = embed_scaling
 

--- a/openvino_xai/methods/white_box/base.py
+++ b/openvino_xai/methods/white_box/base.py
@@ -1,8 +1,8 @@
 # Copyright (C) 2024 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
-from abc import abstractmethod
 import copy
+from abc import abstractmethod
 from typing import Callable
 from venv import logger
 

--- a/tests/unit/explanation/test_explainer.py
+++ b/tests/unit/explanation/test_explainer.py
@@ -4,6 +4,7 @@
 from pathlib import Path
 
 import cv2
+import numpy as np
 import openvino.runtime as ov
 import pytest
 
@@ -137,3 +138,90 @@ class TestExplainer:
         )
         explanation = explainer(self.image, targets=-1, num_masks=10)
         assert len(explanation.saliency_map) == 20
+
+    def test_two_explainers_with_same_model(self):
+        retrieve_otx_model(self.data_dir, MODEL_NAME)
+        model_path = self.data_dir / "otx_models" / (MODEL_NAME + ".xml")
+        model = ov.Core().read_model(model_path)
+
+        explainer = Explainer(
+            model=model,
+            task=Task.CLASSIFICATION,
+        )
+
+        explainer = Explainer(
+            model=model,
+            task=Task.CLASSIFICATION,
+        )
+
+    @pytest.mark.parametrize(
+        "targets",
+        [
+            -1,
+            3,
+            [3],
+            [1, 3],
+            np.uint(1),
+            np.int16(1),
+            np.int64(1),
+            np.array([1]),
+            np.array([1, 2]),
+        ],
+    )
+    def test_different_target_format(self, targets):
+        retrieve_otx_model(self.data_dir, MODEL_NAME)
+        model_path = self.data_dir / "otx_models" / (MODEL_NAME + ".xml")
+        model = ov.Core().read_model(model_path)
+
+        explainer = Explainer(
+            model=model,
+            task=Task.CLASSIFICATION,
+            preprocess_fn=self.preprocess_fn,
+        )
+
+        explanation = explainer(
+            self.image,
+            targets=targets,
+        )
+        if isinstance(targets, int) and targets == -1:
+            assert len(explanation.targets) == 20
+        else:
+            assert len(explanation.targets) == len(np.atleast_1d(np.asarray(targets)))
+
+    def test_overlay_with_resize(self):
+        retrieve_otx_model(self.data_dir, MODEL_NAME)
+        model_path = self.data_dir / "otx_models" / (MODEL_NAME + ".xml")
+        model = ov.Core().read_model(model_path)
+
+        explainer = Explainer(
+            model=model,
+            task=Task.CLASSIFICATION,
+            preprocess_fn=self.preprocess_fn,
+        )
+
+        explanation = explainer(
+            self.image,
+            targets=0,
+            overlay=True,
+            output_size=(50, 70),
+        )
+        assert explanation.saliency_map[0].shape == (50, 70, 3)
+
+    def test_overlay_with_original_image(self):
+        retrieve_otx_model(self.data_dir, MODEL_NAME)
+        model_path = self.data_dir / "otx_models" / (MODEL_NAME + ".xml")
+        model = ov.Core().read_model(model_path)
+
+        explainer = Explainer(
+            model=model,
+            task=Task.CLASSIFICATION,
+            preprocess_fn=self.preprocess_fn,
+        )
+
+        explanation = explainer(
+            self.image,
+            original_input_image=cv2.resize(src=self.image, dsize=(120, 100)),
+            targets=0,
+            overlay=True,
+        )
+        assert explanation.saliency_map[0].shape == (100, 120, 3)

--- a/tests/unit/explanation/test_explanation.py
+++ b/tests/unit/explanation/test_explanation.py
@@ -45,6 +45,11 @@ class TestExplanation:
         assert os.path.isfile(save_path / "test_map_target_aeroplane.jpg")
         assert os.path.isfile(save_path / "test_map_target_bird.jpg")
 
+        explanation = self._get_explanation()
+        explanation.save(save_path)
+        assert os.path.isfile(save_path / "target_aeroplane.jpg")
+        assert os.path.isfile(save_path / "target_bird.jpg")
+
         explanation = self._get_explanation(label_names=None)
         explanation.save(save_path, "test_map")
         assert os.path.isfile(save_path / "test_map_target_0.jpg")

--- a/tests/unit/explanation/test_explanation_utils.py
+++ b/tests/unit/explanation/test_explanation_utils.py
@@ -39,12 +39,12 @@ LABELS_STR = ["bicycle", "bottle"]
 
 def test_get_explain_target_indices_int():
     explain_target_indices = get_explain_target_indices(LABELS_INT, VOC_NAMES)
-    assert explain_target_indices == LABELS_INT
+    assert np.all(explain_target_indices == LABELS_INT)
 
 
 def test_get_explain_target_indices_int_wo_names():
     explain_target_indices = get_explain_target_indices(LABELS_INT)
-    assert explain_target_indices == LABELS_INT
+    assert np.all(explain_target_indices == LABELS_INT)
 
 
 def test_get_explain_target_indices_str():

--- a/tests/unit/explanation/test_visualization.py
+++ b/tests/unit/explanation/test_visualization.py
@@ -99,9 +99,6 @@ class TestVisualizer:
         else:
             explain_targets = [0]
 
-        # if saliency_maps.ndim == 3:
-        #     target_explain_group = TargetExplainGroup.IMAGE
-        #     explain_targets = None
         explanation = Explanation(saliency_maps, targets=explain_targets)
 
         raw_sal_map_dims = len(explanation.shape)

--- a/tests/unit/methods/white_box/test_white_box_method.py
+++ b/tests/unit/methods/white_box/test_white_box_method.py
@@ -36,7 +36,6 @@ class TestActivationMap:
         """Test ActivationMap is created properly."""
         xai_method = ActivationMap(self.model, self.target_layer, prepare_model=False)
 
-        assert xai_method.model_ori == self.model
         assert isinstance(xai_method.model_ori, ov.Model)
         assert xai_method.embed_scaling
         assert not xai_method.per_class
@@ -53,8 +52,8 @@ class TestActivationMap:
         assert len(xai_output_node.get_output_partial_shape(0)) == 3
         assert tuple(xai_output_node.get_output_partial_shape(0))[1:] == (7, 7)
 
-        model_ori_outputs = self.model.outputs
-        model_ori_params = self.model.get_parameters()
+        model_ori_outputs = activationmap_method.model_ori.outputs
+        model_ori_params = activationmap_method.model_ori.get_parameters()
         model_xai = ov.Model([*model_ori_outputs, xai_output_node.output(0)], model_ori_params)
 
         compiled_model = ov.Core().compile_model(model_xai, "CPU")
@@ -95,7 +94,6 @@ class TestReciproCAM:
 
         reciprocam_xai_method = ReciproCAM(self.model, self.target_layer, prepare_model=False)
 
-        assert reciprocam_xai_method.model_ori == self.model
         assert isinstance(reciprocam_xai_method.model_ori, ov.Model)
         assert reciprocam_xai_method.embed_scaling
         assert reciprocam_xai_method.per_class
@@ -112,8 +110,8 @@ class TestReciproCAM:
         assert len(xai_output_node.shape) == 4
         assert tuple(xai_output_node.shape)[2:] == (7, 7)
 
-        model_ori_outputs = self.model.outputs
-        model_ori_params = self.model.get_parameters()
+        model_ori_outputs = reciprocam_xai_method.model_ori.outputs
+        model_ori_params = reciprocam_xai_method.model_ori.get_parameters()
         model_xai = ov.Model([*model_ori_outputs, xai_output_node.output(0)], model_ori_params)
 
         compiled_model = ov.Core().compile_model(model_xai, "CPU")
@@ -154,7 +152,6 @@ class TestViTReciproCAM:
 
         reciprocam_xai_method = ViTReciproCAM(self.model, self.target_layer, prepare_model=False)
 
-        assert reciprocam_xai_method.model_ori == self.model
         assert isinstance(reciprocam_xai_method.model_ori, ov.Model)
         assert reciprocam_xai_method.embed_scaling
         assert reciprocam_xai_method.per_class
@@ -174,8 +171,8 @@ class TestViTReciproCAM:
         assert len(xai_output_node.shape) == 4
         assert tuple(xai_output_node.shape)[2:] == (14, 14)
 
-        model_ori_outputs = self.model.outputs
-        model_ori_params = self.model.get_parameters()
+        model_ori_outputs = reciprocam_xai_method.model_ori.outputs
+        model_ori_params = reciprocam_xai_method.model_ori.get_parameters()
         model_xai = ov.Model([*model_ori_outputs, xai_output_node.output(0)], model_ori_params)
 
         compiled_model = ov.Core().compile_model(model_xai, "CPU")
@@ -234,7 +231,6 @@ class TestDetProbMapXAI:
             prepare_model=False,
         )
 
-        assert detection_xai_method.model_ori == self.model
         assert isinstance(detection_xai_method.model_ori, ov.Model)
         assert detection_xai_method.embed_scaling
         assert detection_xai_method.per_class
@@ -258,8 +254,8 @@ class TestDetProbMapXAI:
         assert len(xai_output_node.shape) == 4
         assert tuple(xai_output_node.shape)[2:] == (23, 23)
 
-        model_ori_outputs = self.model.outputs
-        model_ori_params = self.model.get_parameters()
+        model_ori_outputs = detection_xai_method.model_ori.outputs
+        model_ori_params = detection_xai_method.model_ori.get_parameters()
         model_xai = ov.Model([*model_ori_outputs, xai_output_node.output(0)], model_ori_params)
 
         compiled_model = ov.Core().compile_model(model_xai, "CPU")


### PR DESCRIPTION
- Forward `output_size`
- Fix image size estimation
- Support overlay and resize at the same time
- Stick to `hwc`, TODO: consider switch to `chw`.
- Use numpy to handle targets
- Deepcopy the input model to decouple from the user's model
- Update save method to better handle arg less call
- Support original input image as explainer input: use it for overlay if provided.