### PR TITLE
Fixes for deep dive notebook

### DIFF
--- a/openvino_xai/explainer/utils.py
+++ b/openvino_xai/explainer/utils.py
@@ -157,18 +157,13 @@ def get_score(x: np.ndarray, index: int, activation: ActivationType = Activation
     return x[index]
 
 
-def format_to_hwc(image: np.ndarray) -> np.ndarray:
-    """Format image to HWC."""
-    ori_ndim = image.ndim
-    if image.ndim == 4:
-        image = np.squeeze(image, axis=0)
-
-    dim0, dim1, dim2 = image.shape
-    if dim0 < dim1 and dim0 < dim2:
-        image = image.transpose((1, 2, 0))
-
-    if ori_ndim:
-        return np.expand_dims(image, axis=0)
+def format_to_bhwc(image: np.ndarray) -> np.ndarray:
+    """Format image to BHWC from ndim=3 or ndim=4."""
+    if image.ndim == 3:
+        image = np.expand_dims(image, axis=0)
+    if not is_bhwc_layout(image):
+        # bchw layout -> bhwc
+        image = image.transpose((0, 2, 3, 1))
     return image
 
 
@@ -182,13 +177,11 @@ def is_bhwc_layout(image: np.array) -> bool:
 
 def infer_size_from_image(image: np.ndarray) -> Tuple[int, int]:
     """Estimate image size."""
-    image = format_to_hwc(image)
-
     if image.ndim == 2:
         return image.shape
-    elif image.ndim == 3:
-        h, w, _ = image.shape
-    elif image.ndim == 4:
+
+    image = format_to_bhwc(image)
+    if image.ndim == 4:
         _, h, w, _ = image.shape
     else:
         raise ValueError(f"Supports only two, three, and four dimensional image, but got {image.ndim}.")

--- a/openvino_xai/explainer/utils.py
+++ b/openvino_xai/explainer/utils.py
@@ -172,6 +172,14 @@ def format_to_hwc(image: np.ndarray) -> np.ndarray:
     return image
 
 
+def is_bhwc_layout(image: np.array) -> bool:
+    """Check whether layout of image is BHWC."""
+    _, dim0, dim1, dim2 = image.shape
+    if dim0 > dim2 and dim1 > dim2:  # bhwc layout
+        return True
+    return False
+
+
 def infer_size_from_image(image: np.ndarray) -> Tuple[int, int]:
     """Estimate image size."""
     image = format_to_hwc(image)

--- a/openvino_xai/explainer/visualizer.py
+++ b/openvino_xai/explainer/visualizer.py
@@ -21,9 +21,14 @@ from openvino_xai.explainer.utils import format_to_hwc, infer_size_from_image
 def resize(saliency_map: np.ndarray, output_size: Tuple[int, int]) -> np.ndarray:
     """Resize saliency map."""
     x = saliency_map.transpose((1, 2, 0))
-    x = cv2.resize(x, output_size[::-1])
-    if x.ndim == 2:
-        return np.expand_dims(x, axis=0)
+
+    resized_channels = []
+    for c in range(x.shape[-1]):
+        # Resize fails for tensors with 700 and more channels (targets=all classes scenario)
+        resized_channel = cv2.resize(x[:, :, c], output_size[::-1])
+        resized_channels.append(resized_channel)
+    x = np.stack(resized_channels, axis=-1)
+
     return x.transpose((2, 0, 1))
 
 

--- a/openvino_xai/explainer/visualizer.py
+++ b/openvino_xai/explainer/visualizer.py
@@ -15,7 +15,7 @@ from openvino_xai.explainer.explanation import (
     Explanation,
     Layout,
 )
-from openvino_xai.explainer.utils import format_to_hwc, infer_size_from_image
+from openvino_xai.explainer.utils import format_to_bhwc, infer_size_from_image
 
 
 def resize(saliency_map: np.ndarray, output_size: Tuple[int, int]) -> np.ndarray:
@@ -125,7 +125,7 @@ class Visualizer:
         :type overlay_weight: float
         """
         if original_input_image is not None:
-            original_input_image = format_to_hwc(original_input_image)
+            original_input_image = format_to_bhwc(original_input_image)
 
         saliency_map_dict = explanation.saliency_map
         class_idx_to_return = list(saliency_map_dict.keys())

--- a/openvino_xai/explainer/visualizer.py
+++ b/openvino_xai/explainer/visualizer.py
@@ -22,12 +22,20 @@ def resize(saliency_map: np.ndarray, output_size: Tuple[int, int]) -> np.ndarray
     """Resize saliency map."""
     x = saliency_map.transpose((1, 2, 0))
 
-    resized_channels = []
-    for c in range(x.shape[-1]):
-        # Resize fails for tensors with 700 and more channels (targets=all classes scenario)
-        resized_channel = cv2.resize(x[:, :, c], output_size[::-1])
-        resized_channels.append(resized_channel)
-    x = np.stack(resized_channels, axis=-1)
+    # Resize fails for tensors with 700 and more channels (targets=all classes scenario)
+    # Resizing in batches instead
+    batch_size = 500
+    channels = x.shape[-1]
+    resized_batches = []
+    for start_idx in range(0, channels, batch_size):
+        end_idx = min(start_idx + batch_size, channels)
+        batch = x[:, :, start_idx:end_idx]
+        resized_batch = cv2.resize(batch, output_size[::-1])
+        resized_batches.append(resized_batch)
+    x = np.concatenate(resized_batches, axis=-1)
+
+    if x.ndim == 2:
+        return np.expand_dims(x, axis=0)
 
     return x.transpose((2, 0, 1))
 

--- a/tests/unit/explanation/test_explanation_utils.py
+++ b/tests/unit/explanation/test_explanation_utils.py
@@ -8,6 +8,7 @@ from openvino_xai.explainer.utils import (
     ActivationType,
     get_explain_target_indices,
     get_score,
+    is_bhwc_layout,
 )
 
 VOC_NAMES = [
@@ -77,3 +78,8 @@ def test_get_score():
     x = np.random.rand(1, 5)
     score = get_score(x, 0)
     assert score == x[0][0]
+
+
+def test_is_bhwc_layout():
+    assert is_bhwc_layout(np.empty((1, 224, 224, 3)))
+    assert is_bhwc_layout(np.empty((1, 3, 224, 224))) == False

--- a/tests/unit/explanation/test_visualization.py
+++ b/tests/unit/explanation/test_visualization.py
@@ -59,6 +59,10 @@ def test_resize():
     input_saliency_map = np.random.randint(0, 255, (1, 3, 3), dtype=np.uint8)
     resized_map = resize(input_saliency_map, (5, 5))
     assert resized_map.shape == (1, 5, 5)
+    # Test resizing functionality with 700+ channels to check all classes scenario
+    input_saliency_map = np.random.randint(0, 255, (700, 3, 3), dtype=np.uint8)
+    resized_map = resize(input_saliency_map, (5, 5))
+    assert resized_map.shape == (700, 5, 5)
 
 
 def test_colormap():


### PR DESCRIPTION
- Fix resize failing for targets=All classes. Failed during resizing the tensor with 1001 channels, so I changed code to resize separately per-channel.
- Update black-box to process `(batch, height, width, channel)` model layout together with  `(batch, channel, height, width)` 