### PR TITLE
Make flexible naming in explanation.save

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### What's Changed
 
 * Enable AISE: Adaptive Input Sampling for Explanation of Black-box Models by @negvet in https://github.com/openvinotoolkit/openvino_xai/pull/49
+* Make the naming of saved saliency maps more flexible and return confidence scores by GalyaZalesskaya in https://github.com/openvinotoolkit/openvino_xai/pull/51
 
 ### Known Issues
 

--- a/docs/source/user-guide.md
+++ b/docs/source/user-guide.md
@@ -100,13 +100,13 @@ Here's the example how we can avoid passing `preprocess_fn` by preprocessing dat
 ```python
 import cv2
 import numpy as np
+from typing import Mapping
 import openvino.runtime as ov
-from openvino.runtime.utils.data_helpers.wrappers import OVDict
 
 import openvino_xai as xai
 
 
-def postprocess_fn(x: OVDict):
+def postprocess_fn(x: Mapping):
     # Implementing our own post-process function based on the model's implementation
     # Return "logits" model output
     return x["logits"]
@@ -146,8 +146,8 @@ explanation.save("output_path", "name")
 ```python
 import cv2
 import numpy as np
+from typing import Mapping
 import openvino.runtime as ov
-from openvino.runtime.utils.data_helpers.wrappers import OVDict
 
 import openvino_xai as xai
 
@@ -158,7 +158,7 @@ def preprocess_fn(x: np.ndarray) -> np.ndarray:
     x = np.expand_dims(x, 0)
     return x
 
-def postprocess_fn(x: OVDict):
+def postprocess_fn(x: Mapping):
     # Implementing our own post-process function based on the model's implementation
     # Return "logits" model output
     return x["logits"]
@@ -339,7 +339,7 @@ You can easily save saliency maps with flexible naming options, including prefix
 import cv2
 import numpy as np
 import openvino.runtime as ov
-from openvino.runtime.utils.data_helpers.wrappers import OVDict
+from typing import Mapping
 import openvino_xai as xai
 
 def preprocess_fn(image: np.ndarray) -> np.ndarray:
@@ -348,7 +348,7 @@ def preprocess_fn(image: np.ndarray) -> np.ndarray:
     expanded_image = np.expand_dims(resized_image, 0)
     return expanded_image
 
-def postprocess_fn(output: OVDict):
+def postprocess_fn(output: Mapping):
     """Postprocess the model output."""
     return output["logits"]
 
@@ -391,13 +391,14 @@ explanation = explainer(
 
 # Save saliency maps flexibly
 OUTPUT_PATH = "output_path"
+explanation.save(OUTPUT_PATH)  # target_aeroplane.jpg
 explanation.save(OUTPUT_PATH, "image_name")  # image_name_target_aeroplane.jpg
 explanation.save(OUTPUT_PATH, prefix_name="image_name")  # image_name_target_aeroplane.jpg
-explanation.save(OUTPUT_PATH)  # target_aeroplane.jpg
-# Avoid "target" in names
-explanation.save(OUTPUT_PATH, prefix_name="image_name", target_suffix="")  # image_name_aeroplane.jpg
-explanation.save(OUTPUT_PATH, target_suffix="", postfix_name="class")  # aeroplane_class.jpg
-explanation.save(OUTPUT_PATH, target_suffix="")  # aeroplane.jpg
+
+# Avoid "target" in salinecy map names
+explanation.save(OUTPUT_PATH, suffix_name="")  # aeroplane.jpg
+explanation.save(OUTPUT_PATH, suffix_name="", postfix_name="class")  # aeroplane_class.jpg
+explanation.save(OUTPUT_PATH, prefix_name="image_name", suffix_name="")  # image_name_aeroplane.jpg
 
 # Save saliency maps with confidence scores
 explanation.save(OUTPUT_PATH, postfix_name="conf", confidence_scores=scores_dict)  # target_aeroplane_conf_0.92.jpg```

--- a/docs/source/user-guide.md
+++ b/docs/source/user-guide.md
@@ -333,7 +333,15 @@ model_xai = xai.insert_xai(
 
 ## Saving saliency maps
 
-You can easily save saliency maps with flexible naming options, including prefix, suffix, and postfix. Additionally, you can include the confidence score for each class in the saved saliency map's name.
+You can easily save saliency maps with flexible naming options, including image name as prefix, so saliency maps from the same image will start the same, target prefix, terget suffix.
+
+For the name `image_name_target_aeroplane.jpg`:
+- image_name_prefix = `image_name`,
+- target_prefix = `target`,
+- label name = `aeroplane`,
+- target_suffix = ``.
+
+Additionally, you can include the confidence score for each class in the saved saliency map's name.
 
 ```python
 import cv2
@@ -393,15 +401,15 @@ explanation = explainer(
 OUTPUT_PATH = "output_path"
 explanation.save(OUTPUT_PATH)  # target_aeroplane.jpg
 explanation.save(OUTPUT_PATH, "image_name")  # image_name_target_aeroplane.jpg
-explanation.save(OUTPUT_PATH, prefix_name="image_name")  # image_name_target_aeroplane.jpg
+explanation.save(OUTPUT_PATH, image_name_prefix="image_name")  # image_name_target_aeroplane.jpg
 
 # Avoid "target" in salinecy map names
-explanation.save(OUTPUT_PATH, suffix_name="")  # aeroplane.jpg
-explanation.save(OUTPUT_PATH, suffix_name="", postfix_name="class")  # aeroplane_class.jpg
-explanation.save(OUTPUT_PATH, prefix_name="image_name", suffix_name="")  # image_name_aeroplane.jpg
+explanation.save(OUTPUT_PATH, target_prefix="")  # aeroplane.jpg
+explanation.save(OUTPUT_PATH, target_prefix="", target_suffix="class")  # aeroplane_class.jpg
+explanation.save(OUTPUT_PATH, image_name_prefix="image_name", target_prefix="")  # image_name_aeroplane.jpg
 
 # Save saliency maps with confidence scores
-explanation.save(OUTPUT_PATH, postfix_name="conf", confidence_scores=scores_dict)  # target_aeroplane_conf_0.92.jpg```
+explanation.save(OUTPUT_PATH, target_suffix="conf", confidence_scores=scores_dict)  # target_aeroplane_conf_0.92.jpg```
 ```
 
 

--- a/openvino_xai/explainer/explanation.py
+++ b/openvino_xai/explainer/explanation.py
@@ -144,8 +144,11 @@ class Explanation:
         Dumps saliency map images to the specified directory.
 
         Allows flexibly name the files with the prefix, suffix, and postfix.
+        For the name 'image_name_target_aeroplane.jpg': prefix = 'image_name',
+        suffix = 'target', label name = 'aeroplane', postfix = ''.
+
         save(output_dir) -> target_aeroplane.jpg
-        save(output_dir, prefix_name="test_map", target_suffix="") -> test_map_aeroplane.jpg
+        save(output_dir, prefix_name="test_map", suffix_name="") -> test_map_aeroplane.jpg
         save(output_dir, prefix_name="test_map") -> test_map_target_aeroplane.jpg
         save(output_dir, postfix_name="conf", confidence_scores=scores) -> target_aeroplane_conf_0.92.jpg
 

--- a/openvino_xai/explainer/explanation.py
+++ b/openvino_xai/explainer/explanation.py
@@ -135,32 +135,32 @@ class Explanation:
     def save(
         self,
         dir_path: Path | str,
-        prefix_name: str | None = "",
-        suffix_name: str | None = "target",
-        postfix_name: str | None = "",
+        image_name_prefix: str | None = "",
+        target_prefix: str | None = "target",
+        target_suffix: str | None = "",
         confidence_scores: Dict[int, float] | None = None,
     ) -> None:
         """
         Dumps saliency map images to the specified directory.
 
-        Allows flexibly name the files with the prefix, suffix, and postfix.
+        Allows flexibly name the files with the image_name_prefix, target_prefix, and target_suffix.
         For the name 'image_name_target_aeroplane.jpg': prefix = 'image_name',
-        suffix = 'target', label name = 'aeroplane', postfix = ''.
+        target_prefix = 'target', label name = 'aeroplane', target_suffix = ''.
 
         save(output_dir) -> target_aeroplane.jpg
-        save(output_dir, prefix_name="test_map", suffix_name="") -> test_map_aeroplane.jpg
-        save(output_dir, prefix_name="test_map") -> test_map_target_aeroplane.jpg
-        save(output_dir, postfix_name="conf", confidence_scores=scores) -> target_aeroplane_conf_0.92.jpg
+        save(output_dir, image_name_prefix="test_map", target_prefix="") -> test_map_aeroplane.jpg
+        save(output_dir, image_name_prefix="test_map") -> test_map_target_aeroplane.jpg
+        save(output_dir, target_suffix="conf", confidence_scores=scores) -> target_aeroplane_conf_0.92.jpg
 
         Parameters:
         :param dir_path: The directory path where the saliency maps will be saved.
         :type dir_path: Path | str
-        :param prefix_name: Optional prefix for the file names. Default is an empty string.
-        :type prefix_name: str | None
-        :param suffix_name: Optional suffix for the target. Default is "target".
-        :type suffix_name: str | None
-        :param postfix_name: Optional postfix for the file names. Default is an empty string.
-        :type postfix_name: str | None
+        :param image_name_prefix: Optional prefix for the file names. Default is an empty string.
+        :type image_name_prefix: str | None
+        :param target_prefix: Optional suffix for the target. Default is "target".
+        :type target_prefix: str | None
+        :param target_suffix: Optional suffix for the saliency map name. Default is an empty string.
+        :type target_suffix: str | None
         :param confidence_scores: Dict with confidence scores for each class to saliency maps with them1 Default is None.
         :type confidence_scores: Dict[int, float] | None
 
@@ -168,28 +168,30 @@ class Explanation:
 
         os.makedirs(dir_path, exist_ok=True)
 
-        prefix_name = f"{prefix_name}_" if prefix_name != "" else prefix_name
-        postfix_name = f"_{postfix_name}" if postfix_name != "" else postfix_name
-        template = f"{{prefix_name}}{{suffix_name}}{{target_name}}{postfix_name}.jpg"
+        image_name_prefix = f"{image_name_prefix}_" if image_name_prefix != "" else image_name_prefix
+        target_suffix = f"_{target_suffix}" if target_suffix != "" else target_suffix
+        template = f"{{image_name_prefix}}{{target_prefix}}{{target_name}}{target_suffix}.jpg"
 
-        suffix_name = f"{suffix_name}_" if suffix_name != "" else suffix_name
+        target_prefix = f"{target_prefix}_" if target_prefix != "" else target_prefix
         for cls_idx, map_to_save in self._saliency_map.items():
             map_to_save = cv2.cvtColor(map_to_save, code=cv2.COLOR_RGB2BGR)
             if isinstance(cls_idx, str):
                 target_name = ""
-                if suffix_name == "target_":
+                if target_prefix == "target_":
                     # Default activation map suffix
-                    suffix_name = "activation_map"
-                elif suffix_name == "":
+                    target_prefix = "activation_map"
+                elif target_prefix == "":
                     # Remove the underscore in case of empty suffix
-                    prefix_name = prefix_name[:-1] if prefix_name.endswith("_") else prefix_name
+                    image_name_prefix = image_name_prefix[:-1] if image_name_prefix.endswith("_") else image_name_prefix
             else:
                 target_name = self.label_names[cls_idx] if self.label_names else str(cls_idx)
                 if confidence_scores:
                     class_confidence = confidence_scores[cls_idx]
                     target_name = f"{target_name}_{class_confidence:.2f}"
 
-            image_name = template.format(prefix_name=prefix_name, suffix_name=suffix_name, target_name=target_name)
+            image_name = template.format(
+                image_name_prefix=image_name_prefix, target_prefix=target_prefix, target_name=target_name
+            )
             cv2.imwrite(os.path.join(dir_path, image_name), img=map_to_save)
 
 

--- a/openvino_xai/methods/black_box/aise.py
+++ b/openvino_xai/methods/black_box/aise.py
@@ -3,11 +3,10 @@
 
 import collections
 import math
-from typing import Callable, Dict, List, Tuple
+from typing import Callable, Dict, List, Mapping, Tuple
 
 import numpy as np
 import openvino.runtime as ov
-from openvino.runtime.utils.data_helpers.wrappers import OVDict
 from scipy.optimize import Bounds, direct
 
 from openvino_xai.common.utils import (
@@ -28,7 +27,7 @@ class AISE(BlackBoxXAIMethod):
     :param model: OpenVINO model.
     :type model: ov.Model
     :param postprocess_fn: Post-processing function that extract scores from IR model output.
-    :type postprocess_fn: Callable[[OVDict], np.ndarray]
+    :type postprocess_fn: Callable[[Mapping], np.ndarray]
     :param preprocess_fn: Pre-processing function, identity function by default
         (assume input images are already preprocessed by user).
     :type preprocess_fn: Callable[[np.ndarray], np.ndarray]
@@ -41,7 +40,7 @@ class AISE(BlackBoxXAIMethod):
     def __init__(
         self,
         model: ov.Model,
-        postprocess_fn: Callable[[OVDict], np.ndarray],
+        postprocess_fn: Callable[[Mapping], np.ndarray],
         preprocess_fn: Callable[[np.ndarray], np.ndarray] = IdentityPreprocessFN(),
         device_name: str = "CPU",
         prepare_model: bool = True,

--- a/openvino_xai/methods/black_box/rise.py
+++ b/openvino_xai/methods/black_box/rise.py
@@ -20,7 +20,7 @@ class RISE(BlackBoxXAIMethod):
     :param model: OpenVINO model.
     :type model: ov.Model
     :param postprocess_fn: Post-processing function that extract scores from IR model output.
-    :type postprocess_fn: Callable[[OVDict], np.ndarray]
+    :type postprocess_fn: Callable[[Mapping], np.ndarray]
     :param preprocess_fn: Pre-processing function, identity function by default
         (assume input images are already preprocessed by user).
     :type preprocess_fn: Callable[[np.ndarray], np.ndarray]

--- a/tests/unit/explanation/test_explanation.py
+++ b/tests/unit/explanation/test_explanation.py
@@ -41,7 +41,7 @@ class TestExplanation:
         save_path = tmp_path / "saliency_maps"
 
         explanation = self._get_explanation()
-        explanation.save(save_path, prefix_name="test_map")
+        explanation.save(save_path, image_name_prefix="test_map")
         assert os.path.isfile(save_path / "test_map_target_aeroplane.jpg")
         assert os.path.isfile(save_path / "test_map_target_bird.jpg")
 
@@ -56,21 +56,21 @@ class TestExplanation:
         assert os.path.isfile(save_path / "test_map_target_2.jpg")
 
         explanation = self._get_explanation()
-        explanation.save(save_path, suffix_name="", postfix_name="map")
+        explanation.save(save_path, target_prefix="", target_suffix="map")
         assert os.path.isfile(save_path / "aeroplane_map.jpg")
         assert os.path.isfile(save_path / "bird_map.jpg")
 
         explanation = self._get_explanation()
-        explanation.save(save_path, postfix_name="conf", confidence_scores={0: 0.92, 2: 0.85})
+        explanation.save(save_path, target_suffix="conf", confidence_scores={0: 0.92, 2: 0.85})
         assert os.path.isfile(save_path / "target_aeroplane_0.92_conf.jpg")
         assert os.path.isfile(save_path / "target_bird_0.85_conf.jpg")
 
         explanation = self._get_explanation(saliency_maps=SALIENCY_MAPS_IMAGE, label_names=None)
-        explanation.save(save_path, prefix_name="test_map")
+        explanation.save(save_path, image_name_prefix="test_map")
         assert os.path.isfile(save_path / "test_map_activation_map.jpg")
 
         explanation = self._get_explanation(saliency_maps=SALIENCY_MAPS_IMAGE, label_names=None)
-        explanation.save(save_path, prefix_name="test_map", suffix_name="")
+        explanation.save(save_path, image_name_prefix="test_map", target_prefix="")
         assert os.path.isfile(save_path / "test_map.jpg")
 
     def _get_explanation(self, saliency_maps=SALIENCY_MAPS, label_names=VOC_NAMES):

--- a/tests/unit/explanation/test_explanation.py
+++ b/tests/unit/explanation/test_explanation.py
@@ -41,7 +41,7 @@ class TestExplanation:
         save_path = tmp_path / "saliency_maps"
 
         explanation = self._get_explanation()
-        explanation.save(save_path, "test_map")
+        explanation.save(save_path, prefix_name="test_map")
         assert os.path.isfile(save_path / "test_map_target_aeroplane.jpg")
         assert os.path.isfile(save_path / "test_map_target_bird.jpg")
 
@@ -55,8 +55,22 @@ class TestExplanation:
         assert os.path.isfile(save_path / "test_map_target_0.jpg")
         assert os.path.isfile(save_path / "test_map_target_2.jpg")
 
+        explanation = self._get_explanation()
+        explanation.save(save_path, suffix_name="", postfix_name="map")
+        assert os.path.isfile(save_path / "aeroplane_map.jpg")
+        assert os.path.isfile(save_path / "bird_map.jpg")
+
+        explanation = self._get_explanation()
+        explanation.save(save_path, postfix_name="conf", confidence_scores={0: 0.92, 2: 0.85})
+        assert os.path.isfile(save_path / "target_aeroplane_0.92_conf.jpg")
+        assert os.path.isfile(save_path / "target_bird_0.85_conf.jpg")
+
         explanation = self._get_explanation(saliency_maps=SALIENCY_MAPS_IMAGE, label_names=None)
-        explanation.save(save_path, "test_map")
+        explanation.save(save_path, prefix_name="test_map")
+        assert os.path.isfile(save_path / "test_map_activation_map.jpg")
+
+        explanation = self._get_explanation(saliency_maps=SALIENCY_MAPS_IMAGE, label_names=None)
+        explanation.save(save_path, prefix_name="test_map", suffix_name="")
         assert os.path.isfile(save_path / "test_map.jpg")
 
     def _get_explanation(self, saliency_maps=SALIENCY_MAPS, label_names=VOC_NAMES):

--- a/tests/unit/explanation/test_explanation.py
+++ b/tests/unit/explanation/test_explanation.py
@@ -41,37 +41,37 @@ class TestExplanation:
         save_path = tmp_path / "saliency_maps"
 
         explanation = self._get_explanation()
-        explanation.save(save_path, image_name_prefix="test_map")
-        assert os.path.isfile(save_path / "test_map_target_aeroplane.jpg")
-        assert os.path.isfile(save_path / "test_map_target_bird.jpg")
+        explanation.save(save_path, prefix="image_name_")
+        assert os.path.isfile(save_path / "image_name_aeroplane.jpg")
+        assert os.path.isfile(save_path / "image_name_bird.jpg")
 
         explanation = self._get_explanation()
         explanation.save(save_path)
-        assert os.path.isfile(save_path / "target_aeroplane.jpg")
-        assert os.path.isfile(save_path / "target_bird.jpg")
+        assert os.path.isfile(save_path / "aeroplane.jpg")
+        assert os.path.isfile(save_path / "bird.jpg")
 
         explanation = self._get_explanation(label_names=None)
-        explanation.save(save_path, "test_map")
-        assert os.path.isfile(save_path / "test_map_target_0.jpg")
-        assert os.path.isfile(save_path / "test_map_target_2.jpg")
+        explanation.save(save_path, postfix="_class_map")
+        assert os.path.isfile(save_path / "0_class_map.jpg")
+        assert os.path.isfile(save_path / "2_class_map.jpg")
 
         explanation = self._get_explanation()
-        explanation.save(save_path, target_prefix="", target_suffix="map")
-        assert os.path.isfile(save_path / "aeroplane_map.jpg")
-        assert os.path.isfile(save_path / "bird_map.jpg")
+        explanation.save(save_path, prefix="image_name_", postfix="_map")
+        assert os.path.isfile(save_path / "image_name_aeroplane_map.jpg")
+        assert os.path.isfile(save_path / "image_name_bird_map.jpg")
 
         explanation = self._get_explanation()
-        explanation.save(save_path, target_suffix="conf", confidence_scores={0: 0.92, 2: 0.85})
-        assert os.path.isfile(save_path / "target_aeroplane_0.92_conf.jpg")
-        assert os.path.isfile(save_path / "target_bird_0.85_conf.jpg")
+        explanation.save(save_path, postfix="_conf_", confidence_scores={0: 0.92, 2: 0.85})
+        assert os.path.isfile(save_path / "aeroplane_conf_0.92.jpg")
+        assert os.path.isfile(save_path / "bird_conf_0.85.jpg")
 
         explanation = self._get_explanation(saliency_maps=SALIENCY_MAPS_IMAGE, label_names=None)
-        explanation.save(save_path, image_name_prefix="test_map")
+        explanation.save(save_path, prefix="test_map_")
         assert os.path.isfile(save_path / "test_map_activation_map.jpg")
 
         explanation = self._get_explanation(saliency_maps=SALIENCY_MAPS_IMAGE, label_names=None)
-        explanation.save(save_path, image_name_prefix="test_map", target_prefix="")
-        assert os.path.isfile(save_path / "test_map.jpg")
+        explanation.save(save_path, prefix="test_map_", postfix="_result")
+        assert os.path.isfile(save_path / "test_map_activation_map_result.jpg")
 
     def _get_explanation(self, saliency_maps=SALIENCY_MAPS, label_names=VOC_NAMES):
         explain_targets = [0, 2]


### PR DESCRIPTION
Allows flexibly name the files with the prefix, suffix, and postfix. Add possibility to save confidence scores in saliency map name
 
        save(output_dir) -> aeroplane.jpg
        save(output_dir, prefix="image_name_target_") -> image_name_target_aeroplane.jpg
        save(output_dir, postfix="_class_map") -> aeroplane_class_map.jpg
        save(
            output_dir, prefix="image_name_", postfix="_conf_", confidence_scores=scores
        ) -> image_name_aeroplane_conf_0.85.jpg